### PR TITLE
Support Ruby 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,14 @@
 source 'https://rubygems.org'
 
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
 gemspec
 
 group :test do
   gem 'coveralls', require: false
   gem 'codeclimate-test-reporter', require: false
+
+  # NOTE. fakeweb v1.3.0(latest version) doesn't work on ruby 2.4+, but this is fixed at master branch
+  # c.f. https://github.com/chrisk/fakeweb/issues/62
+  gem 'fakeweb', github: "chrisk/fakeweb"
 end

--- a/connpass.gemspec
+++ b/connpass.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "fakeweb"
 end

--- a/connpass.gemspec
+++ b/connpass.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
   spec.add_dependency "hashie"
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "fakeweb"
 end

--- a/connpass.gemspec
+++ b/connpass.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
   spec.add_dependency "hashie"
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "fakeweb"
 end

--- a/lib/connpass/connection.rb
+++ b/lib/connpass/connection.rb
@@ -8,7 +8,7 @@ module Connpass
     def get path, options = {}
       url = "#{ENDPOINT}#{path}/"
       url = "#{url}?#{build_query(options)}" unless options.empty?
-      open(url).read
+      URI.open(url).read
     end
 
     def convert_response json_str


### PR DESCRIPTION
connpass gem doesn't work on ruby 3.0. So I fixed

# Backtrace
```
  1) Error:
Connpass::.event_search#test_0001_return converted API results:
Errno::ENOENT: No such file or directory @ rb_sysopen - http://connpass.com/api/v1/event/?keyword=Python
    /Users/sue445/workspace/github.com/deeeki/connpass/lib/connpass/connection.rb:11:in `initialize'
    /Users/sue445/workspace/github.com/deeeki/connpass/lib/connpass/connection.rb:11:in `open'
    /Users/sue445/workspace/github.com/deeeki/connpass/lib/connpass/connection.rb:11:in `get'
    /Users/sue445/workspace/github.com/deeeki/connpass/lib/connpass/event.rb:4:in `event_search'
    /Users/sue445/workspace/github.com/deeeki/connpass/spec/connpass_spec.rb:17:in `block (3 levels) in <top (required)>'
```
# Why?
Since Ruby 3.0, `open-uri` cannot be called without `URI` f0c5fd6f9f6ec9ba084fbcde8d2924de8cff9d55

c.f. https://github.com/ruby/ruby/blob/v3_0_0/NEWS.md#compatibility-issues [Misc #15893]

# Others
This patch contains some other minor fixes.

Please read below for details
d080130 1023aab ecf303d